### PR TITLE
Fix randperm overflow for large tensors

### DIFF
--- a/histogram.cu
+++ b/histogram.cu
@@ -103,7 +103,7 @@ void matchHistogram(at::Tensor &featureMaps, at::Tensor &targetHistogram)
 {
   static std::map<unsigned int, at::Tensor> randomIndices;
   if (randomIndices[featureMaps.numel()].numel() != featureMaps.numel())
-    randomIndices[featureMaps.numel()] = torch::randperm(featureMaps.numel()).to(at::kLong).cuda();
+    randomIndices[featureMaps.numel()] = torch::randperm(featureMaps.numel(), torch::TensorOptions().dtype(at::kLong)).cuda();
 
   at::Tensor unsqueezed(featureMaps);
   if (unsqueezed.ndimension() == 1)


### PR DESCRIPTION
Fix overflow bug but creating the random indices tensor directily as a LongTensor type rather than float.